### PR TITLE
[#178124702] Structure output files for dandi

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ This repo contains python source code for converting data files in the [BIDS-NIR
 
 **Note:** this repo is at a WIP stage. Improved organization, documentation, unit tests, etc are expected to be added with time.
 
-
 ## Install Dependencies
 
 ```bash
@@ -19,6 +18,7 @@ $ cd data
 $ wget https://github.com/rob-luke/BIDS-NIRS-Tapping/archive/388d2cdc3ae831fc767e06d9b77298e9c5cd307b.zip -O BIDS-NIRS-Tapping.zip
 $ unzip BIDS-NIRS-Tapping.zip
 $ mv BIDS-NIRS-Tapping-388d2cdc3ae831fc767e06d9b77298e9c5cd307b BIDS-NIRS-Tapping
+$ cd ..
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # finger-tapping-fnirs-to-nwb
 
-This repo contains python source code for converting data files in the [BIDS-NIRS-Tapping](https://github.com/rob-luke/BIDS-NIRS-Tapping) dataset from [SNIRF](https://github.com/fNIRS/snirf) format to [NWB](https://www.nwb.org/nwb-neurophysiology/) format using the [ndx-nirs](https://github.com/agencyenterprise/ndx-nirs) extension. In addition, scripts for arranging the files and uploading to the [DANDI archive](https://gui.dandiarchive.org/) are included.
+This repo contains python source code for converting data files in the [BIDS-NIRS-Tapping](https://github.com/rob-luke/BIDS-NIRS-Tapping) dataset from [SNIRF](https://github.com/fNIRS/snirf) format to [NWB](https://www.nwb.org/nwb-neurophysiology/) format using the [ndx-nirs](https://github.com/agencyenterprise/ndx-nirs) extension. The NWB files will be placed in a directory structure appropriate for upload to the [DANDI archive](https://gui.dandiarchive.org/).
 
 **Note:** this repo is at a WIP stage. Improved organization, documentation, unit tests, etc are expected to be added with time.
 
@@ -16,15 +16,18 @@ $ pip install -r requirements.txt
 ```bash
 $ mkdir data
 $ cd data
-$ wget https://github.com/rob-luke/BIDS-NIRS-Tapping/archive/388d2cdc3ae831fc767e06d9b77298e9c5cd307b.zip BIDS-NIRS-Tapping.zip
+$ wget https://github.com/rob-luke/BIDS-NIRS-Tapping/archive/388d2cdc3ae831fc767e06d9b77298e9c5cd307b.zip -O BIDS-NIRS-Tapping.zip
 $ unzip BIDS-NIRS-Tapping.zip
+$ mv BIDS-NIRS-Tapping-388d2cdc3ae831fc767e06d9b77298e9c5cd307b BIDS-NIRS-Tapping
 ```
 
 ## Usage
 
 ```bash
-$ python convert_tapping_dataset_to_nirs.py data/BIDS-NIRS-Tapping.git
+$ python convert_tapping_dataset_to_nirs.py data/BIDS-NIRS-Tapping data/dandiset
 ```
+
+This will read in the snirf files and BIDS metadata from `data/BIDS-NIRS-Tapping`, and output the nwb files in a dandiset-appropriate filestructure inside of `data/dandiset`. The input dataset path must already exist. If the output path does not exist it will be created.
 
 For more usage information, you can execute:
 ```bash


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178124702

Dandisets seem to follow the directory structure of BIDS but without the metadata files. However, they usually have the nwb files directly in the subject directories instead of a nested `nirs` directory. So that is the file structure I copied here.

The output dataset should have the following structure:
```
├── sub-01
│   └── sub-01_task-tapping_nirs.nwb
├── sub-02
│   └── sub-02_task-tapping_nirs.nwb
├── sub-03
│   └── sub-03_task-tapping_nirs.nwb
├── sub-04
│   └── sub-04_task-tapping_nirs.nwb
└── sub-05
    └── sub-05_task-tapping_nirs.nwb
```

A required OUTPUT_PATH argument was added to the script and the documentation was updated.

Note: we decided to take unit tests oos for now, but they will be added here: https://www.pivotaltracker.com/story/show/178536860